### PR TITLE
Whitelist world types

### DIFF
--- a/src/enum/ProfileType.ts
+++ b/src/enum/ProfileType.ts
@@ -1,4 +1,4 @@
-enum ProfileType {
+export enum ProfileType {
   STANDARD = 'STANDARD',
   BETA = 'BETA',
   DEADMAN = 'DEADMAN',
@@ -6,4 +6,7 @@ enum ProfileType {
   SHATTERED_RELICS_LEAGUE = 'SHATTERED_RELICS_LEAGUE'
 }
 
-export default ProfileType;
+export enum AllowedProfileType {
+  STANDARD = 'STANDARD',
+  DEADMAN = 'DEADMAN'
+}

--- a/src/migration/1639242709852-PlayerDataAddProfile.ts
+++ b/src/migration/1639242709852-PlayerDataAddProfile.ts
@@ -1,5 +1,5 @@
 import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
-import ProfileType from '../enum/ProfileType';
+import { ProfileType } from '../enum/ProfileType';
 
 export class PlayerDataAddProfile1639242709852 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/orm/PlayerData.ts
+++ b/src/orm/PlayerData.ts
@@ -1,5 +1,5 @@
 import { Entity, Column, PrimaryColumn } from 'typeorm';
-import ProfileType from '../enum/ProfileType';
+import { ProfileType } from '../enum/ProfileType';
 import PlayerDataType from '../enum/PlayerDataType';
 
 @Entity()

--- a/src/routes/runelite.ts
+++ b/src/routes/runelite.ts
@@ -36,6 +36,9 @@ router.post('/submit', async (req, res) => {
   if (!req.body.username || !req.body.data || !req.body.data.varb || !req.body.data.varp) {
     return res.status(400).json({error: "Missing required data."})
   }
+  if (!req.body.profile || !(req.body.profile in AllowedProfileType)) {
+    return res.status(400).json({ error: 'Cannot save data for this world type.' });
+  }
 
   await RLService.parseAndSaveData(req.body);
   res.json({ success: true });
@@ -52,6 +55,9 @@ router.get('/player/:username/:profile?', async (req, res) => {
   let profile = null;
   if (req.params.profile) {
     profile = ProfileType[req.params.profile];
+  }
+  if (!(profile in AllowedProfileType)) {
+    return res.status(400).json({ error: 'Cannot query data for this world type.' });
   }
 
   const data = await RLService.getDataForUser(req.params.username, profile) as RuneLiteGetDataReturn;

--- a/src/routes/runelite.ts
+++ b/src/routes/runelite.ts
@@ -6,7 +6,7 @@ import { CombatAchievementsService } from '../services/CombatAchievementsService
 import { LeagueService } from '../services/LeagueService';
 import { MusicService } from '../services/MusicService';
 import { QuestService } from '../services/QuestService';
-import ProfileType from '../enum/ProfileType';
+import { AllowedProfileType, ProfileType } from '../enum/ProfileType';
 
 const router = express.Router();
 

--- a/src/services/RuneLiteService.ts
+++ b/src/services/RuneLiteService.ts
@@ -1,4 +1,4 @@
-import ProfileType from '../enum/ProfileType';
+import { ProfileType } from '../enum/ProfileType';
 import PlayerDataType from '../enum/PlayerDataType';
 import PlayerData from '../orm/PlayerData';
 import DBService from './DBService';


### PR DESCRIPTION
* Creates the `AllowedProfileType` enum to hold allowed worlds for read/write
* Only allow submissions and reads for `DEADMAN` and `STANDARD` profile types

**PLEASE DO NOT DEPLOY UNTIL WE FIX THE CLIENT JS SIDE**
https://oldschool.runescape.wiki/w/MediaWiki:Gadget-wikisync-core.js#L-20
^ `NORMAL` in the url should be `STANDARD`, this is actually a bug where we send `NORMAL` -> no profile so it becomes null -> db query uses `STANDARD` as default. This change will break everything on the wiki as a result since `NORMAL` will fail.